### PR TITLE
add data-binary as valid data source

### DIFF
--- a/curl-parser.js
+++ b/curl-parser.js
@@ -94,6 +94,9 @@
         if (cmd.data) {
             loadData(cmd.data);
         }
+        if (cmd["data-binary"]) {
+            loadData(cmd["data-binary"]);
+        }
         if (dataAscii.length > 0) {
             relevant.data.ascii = dataAscii.join("&");
         }


### PR DESCRIPTION
Chrome exports curl commands with --data-binary
